### PR TITLE
Add GL-MIFI board

### DIFF
--- a/boards.yml
+++ b/boards.yml
@@ -300,6 +300,10 @@ gl_inet_gl_mt300a:
   switch:   ["1 2 3 4 6t", "0 6t"]
   radios:   ["radio0"]
 
+gl_mifi:
+  lan_wan:  ["eth1", "eth0"]
+  radios:   ["radio0"]
+
 hiwifi_hc6361:
   lan_wan:  ["eth0", "eth1"]
   switch:   ["0 1 2 3 4"]


### PR DESCRIPTION
Hi, 

This is an update to add the GL-MIFI Board to the list.
https://www.gl-inet.com/mifi/#1442566013976-f19448f7-2698

Thanks